### PR TITLE
Fix uninitialised key value for root TreeNode

### DIFF
--- a/src/static_tree.rs
+++ b/src/static_tree.rs
@@ -10,7 +10,11 @@ Summary:
 */
 
 use crate::dynamic_array::DynamicArray;
-use std::{alloc::Layout, fmt::Debug};
+use std::alloc::Layout;
+
+#[cfg(debug_assertions)]
+use std::fmt::Debug;
+
 
 // TreeOffset is an i32 index into the DynamicArray structure in the StaticTree
 // It is used to specify the offset to find an item

--- a/src/static_tree.rs
+++ b/src/static_tree.rs
@@ -8,7 +8,6 @@ Summary:
 
     Due to the continous nature of StaticTree it is recommended to store as little data as possible in the actual tree structure
 */
-
 use crate::dynamic_array::DynamicArray;
 use std::alloc::Layout;
 
@@ -21,7 +20,7 @@ use std::fmt::Debug;
 type TreeOffset = i32;
 
 pub struct TreeNode<T, Idx: PartialEq> {
-    pub key: Idx,
+    pub key: Option<Idx>,
     pub value: Option<T>,
     pub list_length: i32,
     pub list_head: TreeOffset
@@ -70,7 +69,7 @@ impl StaticTree {
 
             // Check if node matches index
             // If not then we continue to the next node
-            if test_node.key != index[keychain_idx] {
+            if test_node.key.as_ref() != Some(&index[keychain_idx]) {
                 if branch_idx == current_node.list_length { return None; } // Null check.
 
                 // Increment state variables

--- a/src/static_tree_planner.rs
+++ b/src/static_tree_planner.rs
@@ -74,7 +74,7 @@ impl<T, Idx: PartialEq + Clone + Default> StaticTreePlanner<T, Idx> {
 
         // Write root node
         let node0 = tree.raw().get_mut::<TreeNode<T, Idx>>(0);
-        node0.key = Idx::default();
+        node0.key = None;
         node0.list_length = stack.get(0).unwrap().nodes.len() as i32;
         node0.list_head = node_size;
 
@@ -83,7 +83,7 @@ impl<T, Idx: PartialEq + Clone + Default> StaticTreePlanner<T, Idx> {
             let sub_node = &mut stack.get_mut(0).unwrap().nodes[i];
             let branch = tree.raw().get_mut::<TreeNode<T, Idx>>(pool_offset as usize);
 
-            branch.key          = sub_node.key.clone();
+            branch.key          = Some(sub_node.key.clone());
             branch.value        = sub_node.value.take();
             branch.list_length  = sub_node.nodes.len() as i32;
             branch.list_head    = -1;
@@ -111,7 +111,7 @@ impl<T, Idx: PartialEq + Clone + Default> StaticTreePlanner<T, Idx> {
                     let branch = tree.raw().get_mut::<TreeNode<T, Idx>>(pool_offset as usize);
 
                     // Initialise branch values
-                    branch.key          = node.nodes[i].key.clone();
+                    branch.key          = Some(node.nodes[i].key.clone());
                     branch.value        = node.nodes[i].value.take();
                     branch.list_length  = node.nodes[i].nodes.len() as i32;
                     branch.list_head    = -1;
@@ -172,7 +172,6 @@ impl<T, Idx: PartialEq + Clone + Default> StaticTreePlanner<T, Idx> {
             }
         };
 
-        println!("Calcultaed node count: {}", node_count);
         return node_count * std::mem::size_of::<TreeNode<T, Idx>>();
 
     }
@@ -193,7 +192,7 @@ mod tests {
     use super::*;
 
     // Helper function for checking that a given TreeNode is valid
-    fn check_node(node: &TreeNode<i32, &str>, key: &str, value: Option<i32>, list_length: i32, list_head: i32) -> bool {
+    fn check_node(node: &TreeNode<i32, &str>, key: Option<&str>, value: Option<i32>, list_length: i32, list_head: i32) -> bool {
         return node.key == key &&
             node.value == value &&
             node.list_length == list_length &&
@@ -223,22 +222,22 @@ mod tests {
         // Just the underlying memory structure
 
         // Root Node
-        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(0), "", None, 2, 32));
+        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(0), None, None, 2, 32));
 
         // "a"
-        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(32), "a", None, 1, 96));
+        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(32), Some("a"), None, 1, 96));
 
         // "e"
-        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(64), "e", Some(3), 0, -1));
+        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(64), Some("e"), Some(3), 0, -1));
         
         // "b"
-        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(96), "b", None, 2, 128));
+        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(96), Some("b"), None, 2, 128));
 
         // "c"
-        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(128), "c", Some(1), 0, -1));
+        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(128), Some("c"), Some(1), 0, -1));
 
         // "d"
-        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(160), "d", Some(2), 0, -1));
+        assert!(check_node(tree.raw().get::<TreeNode<i32, &str>>(160), Some("d"), Some(2), 0, -1));
     }
 
 }

--- a/src/static_tree_planner.rs
+++ b/src/static_tree_planner.rs
@@ -74,6 +74,7 @@ impl<T, Idx: PartialEq + Clone + Default> StaticTreePlanner<T, Idx> {
 
         // Write root node
         let node0 = tree.raw().get_mut::<TreeNode<T, Idx>>(0);
+        node0.key = Idx::default();
         node0.list_length = stack.get(0).unwrap().nodes.len() as i32;
         node0.list_head = node_size;
 


### PR DESCRIPTION
As raised in #1 the root node of the tree may not always be initialised to empty depending on memory conditions. While not directly reproducible I see that this might cause an error and we now correctly initialise the `TreeNode.key` field using `Idx::default()`